### PR TITLE
Prefer ESM entry over UMD in browser bundlers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bresenham-zingl",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bresenham-zingl",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "MIT",
       "devDependencies": {
         "gh-pages": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bresenham-zingl",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "description": "Bresenham rasterisation algorithms by Alois Zingl",
   "main": "dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,16 @@
   "description": "Bresenham rasterisation algorithms by Alois Zingl",
   "main": "dist/index.mjs",
   "module": "dist/index.mjs",
-  "browser": "dist/index.umd.js",
   "unpkg": "dist/index.umd.js",
   "types": "dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
+      "default": "./dist/index.mjs"
+    }
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
The `browser` field pointed bundlers (e.g. esbuild with default browser platform) at `dist/index.umd.js`. When another library bundles this package, esbuild inlines the whole self-contained UMD wrapper (including its own `define()` AMD call) verbatim instead of treating it as tree-shakeable ESM.

If the consuming library is itself a UMD/AMD bundle, this produces two independent anonymous `define()` calls in one output file, which AMD loaders like RequireJS reject as "Mismatched anonymous define() module".

This replaces the `browser` field with a standard `exports` map (no `browser` condition) pointing to the ESM/CJS entries, so bundlers resolve the ESM source instead of the pre-built UMD bundle. `dist/index.umd.js` is still shipped and referenced via `unpkg` for direct `<script>` tag / CDN usage.